### PR TITLE
Fix winform project not displaying entry list on database creation and opening

### DIFF
--- a/KrepostWinForms/Forms/MainForm.cs
+++ b/KrepostWinForms/Forms/MainForm.cs
@@ -47,6 +47,7 @@ namespace KrepostWinForms.Forms
         #region menuStripFile Functions
         private void menuStripFileNew_Click(object sender, EventArgs e)
         {
+            // Handle any unsaved changes.
             if (Program.SavedDatabase == false)
             {
                 var result = ConfirmChanges();
@@ -67,10 +68,15 @@ namespace KrepostWinForms.Forms
             }
 
             Form newDbForm = new NewDatabaseForm();
-            newDbForm.ShowDialog();
+            var formResult = newDbForm.ShowDialog();
+            if (formResult == DialogResult.OK)
+            {
+                RefreshTreeView();
+            }
         }
         private void menuStripFileOpen_Click(object sender, EventArgs e)
         {
+            // Handle any unsaved changes.
             if (Program.SavedDatabase == false)
             {
                 var result = ConfirmChanges();
@@ -80,7 +86,7 @@ namespace KrepostWinForms.Forms
                         Middleware.DatabaseUtils.SaveDatabase(Program.CurrentDb, Program.CurrentKey, Program.DbFilePath);
                     else
                     {
-                        string str2 = "A loaded database was not found. No changes could be saved.";
+                        string str2 = "Something went wronge. No dabatase could be loaded.";
                         MessageBox.Show(str2, "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
@@ -90,10 +96,15 @@ namespace KrepostWinForms.Forms
                 }
             }
 
+            // Open database.
             if (Utility.OpenDatabaseFile())
             {
                 Form openDbForm = new OpenDatabaseForm();
-                openDbForm.ShowDialog();
+                var formResult = openDbForm.ShowDialog();
+                if (formResult == DialogResult.OK)
+                {
+                    RefreshTreeView();
+                }
             }
         }
         private void menuStripFileSave_Click(object sender, EventArgs e)

--- a/KrepostWinForms/Forms/NewDatabaseForm.cs
+++ b/KrepostWinForms/Forms/NewDatabaseForm.cs
@@ -1,6 +1,4 @@
-﻿using KrepostLib.Cryptography;
-
-using KrepostWinForms.Middleware;
+﻿using KrepostWinForms.Middleware;
 
 namespace KrepostWinForms.Forms
 {
@@ -29,22 +27,31 @@ namespace KrepostWinForms.Forms
                 // Check if key generation failed.
                 if (Program.CurrentKey != null)
                 {
-                    // Create new database and dispose of user input.
-                    DatabaseUtils.NewDatabase(secureStringTextBoxTop.DataHash, Program.CurrentKey, secureStringTextBoxTop.DataSalt);
+                    // Create new database.
+                    if (DatabaseUtils.NewDatabase(secureStringTextBoxTop.DataHash, Program.CurrentKey, secureStringTextBoxTop.DataSalt))
+                        DialogResult = DialogResult.OK;
+                    else
+                        DialogResult=DialogResult.Abort;
+
+                    // Dispose of user input.
                     secureStringTextBoxTop.Data.Dispose();
                     secureStringTextBoxBottom.Data.Dispose();
                     Close();
-                    return;
                 }
-                MessageBox.Show("Entryption key has not created correctly.A new database has not been created.",
-                    "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                Close();
+                else
+                {
+                    MessageBox.Show("Entryption key was not created correctly. A new database has not been created.",
+                        "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    DialogResult = DialogResult.Abort;
+                    Close();
+                }
             }
         }
         private void buttonCancel_Click(object sender, EventArgs e)
         {
             secureStringTextBoxTop.Data.Dispose();
             secureStringTextBoxBottom.Data.Dispose();
+            DialogResult = DialogResult.Cancel;
             Close();
         }
     }

--- a/KrepostWinForms/Forms/OpenDatabaseForm.cs
+++ b/KrepostWinForms/Forms/OpenDatabaseForm.cs
@@ -26,6 +26,7 @@ namespace KrepostWinForms.Forms
         {
             if (!KrepostLib.Utility.CompareStrings(Program.CurrentDbHead.AccessHash, secureStringTextBox.DataHash))
             {
+                DialogResult = DialogResult.Abort;
                 MessageBox.Show("Password is incorrect.", "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
@@ -43,12 +44,14 @@ namespace KrepostWinForms.Forms
                 // Decrypt and deserialize the last component needed for a complete database
                 if (!Utility.AccessDatabaseBody(Program.CurrentDbFile, Program.CurrentDbHead, Program.CurrentKey))
                 {
+                    DialogResult = DialogResult.Abort;
                     MessageBox.Show("Something went wrong while opening encrypted database content.", "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
                 else
                 {
                     // Marks that a database is opened
                     Program.OpenDatabase = true;
+                    DialogResult = DialogResult.OK;
                 }
 
                 secureStringTextBox.Data.Dispose();
@@ -59,6 +62,7 @@ namespace KrepostWinForms.Forms
         private void buttonCancel_Click(object sender, EventArgs e)
         {
             secureStringTextBox.Data.Dispose();
+            DialogResult = DialogResult.Cancel;
             Close();
         }
     }


### PR DESCRIPTION
Calls for refreshing the tree view when a database is created or opened. Adds checks to confirm the actions have been completed, rather than aborted.