### PR TITLE
Fix winform project pasting into SecureStringTextBox breaks the box

### DIFF
--- a/KrepostWinForms/Forms/AddEntryForm.Designer.cs
+++ b/KrepostWinForms/Forms/AddEntryForm.Designer.cs
@@ -30,10 +30,10 @@ namespace KrepostWinForms.Forms
         /// </summary>
         private void InitializeComponent()
         {
-            System.Security.SecureString secureString1 = new System.Security.SecureString();
-            System.Security.SecureString secureString2 = new System.Security.SecureString();
-            System.Security.SecureString secureString3 = new System.Security.SecureString();
-            System.Security.SecureString secureString4 = new System.Security.SecureString();
+            System.Security.SecureString secureString5 = new System.Security.SecureString();
+            System.Security.SecureString secureString6 = new System.Security.SecureString();
+            System.Security.SecureString secureString7 = new System.Security.SecureString();
+            System.Security.SecureString secureString8 = new System.Security.SecureString();
             this.labelTitle = new System.Windows.Forms.Label();
             this.labelUsername = new System.Windows.Forms.Label();
             this.labelEmail = new System.Windows.Forms.Label();
@@ -106,7 +106,7 @@ namespace KrepostWinForms.Forms
             // 
             // secureStringTextBoxPassword
             // 
-            this.secureStringTextBoxPassword.Data = secureString1;
+            this.secureStringTextBoxPassword.Data = secureString5;
             this.secureStringTextBoxPassword.DataHash = null;
             this.secureStringTextBoxPassword.DataSalt = null;
             this.secureStringTextBoxPassword.Location = new System.Drawing.Point(97, 180);
@@ -117,7 +117,7 @@ namespace KrepostWinForms.Forms
             // 
             // secureStringTextBoxEmail
             // 
-            this.secureStringTextBoxEmail.Data = secureString2;
+            this.secureStringTextBoxEmail.Data = secureString6;
             this.secureStringTextBoxEmail.DataHash = null;
             this.secureStringTextBoxEmail.DataSalt = null;
             this.secureStringTextBoxEmail.Location = new System.Drawing.Point(97, 140);
@@ -128,7 +128,7 @@ namespace KrepostWinForms.Forms
             // 
             // secureStringTextBoxUsername
             // 
-            this.secureStringTextBoxUsername.Data = secureString3;
+            this.secureStringTextBoxUsername.Data = secureString7;
             this.secureStringTextBoxUsername.DataHash = null;
             this.secureStringTextBoxUsername.DataSalt = null;
             this.secureStringTextBoxUsername.Location = new System.Drawing.Point(97, 100);
@@ -139,7 +139,7 @@ namespace KrepostWinForms.Forms
             // 
             // secureStringTextBoxNote
             // 
-            this.secureStringTextBoxNote.Data = secureString4;
+            this.secureStringTextBoxNote.Data = secureString8;
             this.secureStringTextBoxNote.DataHash = null;
             this.secureStringTextBoxNote.DataSalt = null;
             this.secureStringTextBoxNote.Location = new System.Drawing.Point(97, 260);

--- a/KrepostWinForms/Forms/AddEntryForm.cs
+++ b/KrepostWinForms/Forms/AddEntryForm.cs
@@ -58,7 +58,8 @@ namespace KrepostWinForms.Forms
         {
             if (textBoxTitle.Text == null || textBoxTitle.Text.Length <= 0)
             {
-                MessageBox.Show("No title set for entry. An entry must contain a title.", "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("No title set for entry. An entry must contain a title.",
+                    "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
             if ((secureStringTextBoxUsername.Data == null ||
@@ -66,12 +67,14 @@ namespace KrepostWinForms.Forms
                 (secureStringTextBoxEmail.Data == null ||
                 secureStringTextBoxEmail.Data.Length <= 0))
             {
-                MessageBox.Show("No username or email set for entry. An entry must contain at least one.", "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("No username or email set for entry. An entry must contain at least one.",
+                    "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
             if (secureStringTextBoxPassword.Data == null || secureStringTextBoxPassword.Data.Length <= 0)
             {
-                MessageBox.Show("No username set for entry. An entry must contain a title.", "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("No password set for entry. An entry must contain a password.", 
+                   "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
             return true;

--- a/KrepostWinForms/Forms/EditEntryForm.cs
+++ b/KrepostWinForms/Forms/EditEntryForm.cs
@@ -106,7 +106,7 @@ namespace KrepostWinForms.Forms
             }
             if (secureStringTextBoxPassword.Data == null || secureStringTextBoxPassword.Data.Length <= 0)
             {
-                MessageBox.Show("No username set for entry. An entry must contain a title.", "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("No password set for entry. An entry must contain a password.", "Krepost", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
             return true;

--- a/KrepostWinForms/UI/SecureStringTextBox.cs
+++ b/KrepostWinForms/UI/SecureStringTextBox.cs
@@ -33,6 +33,8 @@ namespace KrepostWinForms.UI
         public SecureStringTextBox()
         {
             InitializeComponent();
+
+            InputBox.ShortcutsEnabled = false;
             
             emptyStatus = true;
         }


### PR DESCRIPTION
Disables shortcuts for SecureStringTextBox. Fixes input validation massages on AddEntry and EditEntry forms to correctly show what the error is.