### PR TITLE
Fix WinForms proejct MainForm to correctly call EnableAvailableIteams function

### DIFF
--- a/KrepostWinForms/Forms/MainForm.cs
+++ b/KrepostWinForms/Forms/MainForm.cs
@@ -76,7 +76,7 @@ namespace KrepostWinForms.Forms
             {
                 RefreshTreeView();
             }
-            EnableUnavaialbeIteams();
+            EnableAvailableIteams();
         }
         private void menuStripFileOpen_Click(object sender, EventArgs e)
         {
@@ -110,7 +110,7 @@ namespace KrepostWinForms.Forms
                     RefreshTreeView();
                 }
             }
-            EnableUnavaialbeIteams();
+            EnableAvailableIteams();
         }
         private void menuStripFileSave_Click(object sender, EventArgs e)
         {


### PR DESCRIPTION
Fixes wrong function name being called.